### PR TITLE
Add in MYSQL_ROOT_PASSWORD variable to patching command

### DIFF
--- a/upgrade-guacamole.sh
+++ b/upgrade-guacamole.sh
@@ -231,7 +231,11 @@ if [[ "${INSTALL_MYSQL}" = true ]]; then
         FILEVERSION=$(echo ${FILE} | grep -oP 'upgrade-pre-\K[0-9\.]+(?=\.)')
         if [[ $(echo -e "${FILEVERSION}\n${OLD_GUAC_VERSION}" | sort -V | head -n1) == ${OLD_GUAC_VERSION} && ${FILEVERSION} != ${OLD_GUAC_VERSION} ]]; then
             echo "Patching ${GUAC_DB} with ${FILE}"
-            mysql -u root -p${MYSQL_ROOT_PWD} -D ${GUAC_DB} -h ${MYSQL_HOST} -P ${MYSQL_PORT} <guacamole-auth-jdbc-${NEW_GUAC_VERSION}/mysql/schema/upgrade/${FILE} &>>${INSTALL_LOG}
+	    if [[ ! -z "$MYSQL_ROOT_PWD" ]]; then
+                mysql -u root -p${MYSQL_ROOT_PWD} -D ${GUAC_DB} -h ${MYSQL_HOST} -P ${MYSQL_PORT} <guacamole-auth-jdbc-${NEW_GUAC_VERSION}/mysql/schema/upgrade/${FILE} &>>${INSTALL_LOG}
+            else
+		mysql -u root -D ${GUAC_DB} -h ${MYSQL_HOST} -P ${MYSQL_PORT} <guacamole-auth-jdbc-${NEW_GUAC_VERSION}/mysql/schema/upgrade/${FILE} &>>${INSTALL_LOG}
+	    fi
         fi
     done
     if [[ $? -ne 0 ]]; then

--- a/upgrade-guacamole.sh
+++ b/upgrade-guacamole.sh
@@ -231,7 +231,7 @@ if [[ "${INSTALL_MYSQL}" = true ]]; then
         FILEVERSION=$(echo ${FILE} | grep -oP 'upgrade-pre-\K[0-9\.]+(?=\.)')
         if [[ $(echo -e "${FILEVERSION}\n${OLD_GUAC_VERSION}" | sort -V | head -n1) == ${OLD_GUAC_VERSION} && ${FILEVERSION} != ${OLD_GUAC_VERSION} ]]; then
             echo "Patching ${GUAC_DB} with ${FILE}"
-            mysql -u root -D ${GUAC_DB} -h ${MYSQL_HOST} -P ${MYSQL_PORT} <guacamole-auth-jdbc-${NEW_GUAC_VERSION}/mysql/schema/upgrade/${FILE} &>>${INSTALL_LOG}
+            mysql -u root -p${MYSQL_ROOT_PWD} -D ${GUAC_DB} -h ${MYSQL_HOST} -P ${MYSQL_PORT} <guacamole-auth-jdbc-${NEW_GUAC_VERSION}/mysql/schema/upgrade/${FILE} &>>${INSTALL_LOG}
         fi
     done
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Despite a mysql root password being set it was not being used when upgrading the guacamole-auth-jdbc extension. This is now used in the command.